### PR TITLE
Referencing old method in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,4 +158,4 @@ You can search for locations, media, tags, and users.
     $locations = $instagram->searchLocations( $lat, $lng );
     $media = $instagram->searchMedia( $lat, $lng );
     $tags = $instagram->searchTags( 'tag' );
-    $users = $instagram->searchUsersByName( 'username' );
+    $users = $instagram->searchUsers( 'username' );


### PR DESCRIPTION
The docs are currently referencing a method named searchUsersByName, which pulls a user based on username. As far as I can tell, this method name has changed to searchUsers. Updated README.md to reflect.
