### PR TITLE
Add shortcut method for retrieving media belonging to a certain tag.

### DIFF
--- a/Instagram/Instagram.php
+++ b/Instagram/Instagram.php
@@ -10,6 +10,7 @@ namespace Instagram;
 
 use \Instagram\Collection\MediaSearchCollection;
 use \Instagram\Collection\TagCollection;
+use \Instagram\Collection\TagMediaCollection;
 use \Instagram\Collection\UserCollection;
 use \Instagram\Collection\MediaCollection;
 use \Instagram\Collection\LocationCollection;
@@ -265,6 +266,18 @@ class Instagram extends \Instagram\Core\BaseObjectAbstract {
         $params['lng'] = (float)$lng;
         $location_collection = new LocationCollection( $this->proxy->searchLocations( $params ), $this->proxy );
         return $location_collection;
+    }
+
+	/**
+	 * Get tag media
+	 *
+	 * @param string $tag
+	 * @param array $params Optional params to pass to the endpoint
+	 * @return TagMediaCollection
+	 */
+    public function searchTagMedia( $tag, array $params = null ) {
+        $params = (array)$params;
+        return new TagMediaCollection( $this->proxy->getTagMedia( $tag, $params ), $this->proxy );
     }
 
 }

--- a/Tests/InstagramTest.php
+++ b/Tests/InstagramTest.php
@@ -142,4 +142,12 @@ class InstagramTest extends PHPUnit_Framework_TestCase {
         $this->assertInstanceOf( '\Instagram\Collection\TagCollection', $tags );
     }
 
+    public function testSearchTagMedia() {
+        $instagram = new Instagram\Instagram($this->access_token);
+        $media = $instagram->searchTagMedia($this->valid_tag);
+        $this->assertInstanceOf('\Instagram\Collection\TagMediaCollection', $media);
+        $this->assertTrue((bool)strlen($media->getNextMaxTagId()));
+    }
+
+
 }


### PR DESCRIPTION
I added a method for retrieving media belonging to a tag, without creating a Tag instance first. This prevents from having to do a tag API call.
