### PR TITLE
Fix relative path

### DIFF
--- a/Tests/_autoloader.php
+++ b/Tests/_autoloader.php
@@ -2,5 +2,5 @@
 
 require( '_SplClassLoader.php' );
 
-$loader = new SplClassLoader( 'Instagram', '../' );
+$loader = new SplClassLoader( 'Instagram', __DIR__ . '/../' );
 $loader->register();


### PR DESCRIPTION
On WordPress instalations for example, the include path of each
file is not necessarily the path to the given file.
Adding __DIR__ will preven this from being a problem.
